### PR TITLE
BibTeX “abstract” field / PHPUnit default config file

### DIFF
--- a/src/Geissler/Converter/Standard/BibTeX/Parser.php
+++ b/src/Geissler/Converter/Standard/BibTeX/Parser.php
@@ -212,6 +212,7 @@ class Parser implements ParserInterface
 
             $mapper =   array(
                 'title'             =>  'setTitle',
+                'abstract'          =>  'setAbstract',
                 'volume'            =>  'setVolume',
                 'number'            =>  'setNumber',
                 'note'              =>  'setNote',

--- a/tests/phpunit.xml.dist
+++ b/tests/phpunit.xml.dist
@@ -1,0 +1,7 @@
+<phpunit bootstrap="bootstrap.php">
+    <testsuites>
+        <testsuite name="All_Tests">
+            <directory>src</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>


### PR DESCRIPTION
I made two minor changes/additions:
1. Added the missing “abstract” in BibTeX\Parser::create(). (A client needs access to abstracts from a BibTeX file.)
2. Added a default PHPUnit config file. This way, one can simply “cd” into the “tests” directory and execute “phpunit” without even thinking about the bootstrap file or where the tests are.
