### PR TITLE
Remove trailing spaces

### DIFF
--- a/library/bibtexParse/PARSECREATORS.php
+++ b/library/bibtexParse/PARSECREATORS.php
@@ -27,8 +27,13 @@ http://bibliophile.sourceforge.net
 
 class PARSECREATORS
 {
+	function ___construct()
+	{
+	}
+
 	function PARSECREATORS()
 	{
+		self::___construct();
 	}
 /* Create writer arrays from bibtex input.
 'author field can be (delimiters between authors are 'and' or '&'):

--- a/library/bibtexParse/PARSECREATORS.php
+++ b/library/bibtexParse/PARSECREATORS.php
@@ -39,7 +39,7 @@ class PARSECREATORS
 	function parse($input)
 	{
 		$input = trim($input);
-// split on ' and ' 
+// split on ' and '
 		$authorArray = preg_split("/\s(and|&)\s/i", $input);
 		foreach($authorArray as $value)
 		{
@@ -51,11 +51,11 @@ class PARSECREATORS
 			if($size == 1)
 			{
 // Is complete surname enclosed in {...}, unless the string starts with a backslash (\) because then it is
-// probably a special latex-sign.. 
-// 2006.02.11 DR: in the last case, any NESTED curly braces should also be taken into account! so second 
+// probably a special latex-sign..
+// 2006.02.11 DR: in the last case, any NESTED curly braces should also be taken into account! so second
 // clause rules out things such as author="a{\"{o}}"
-// 
-                if(preg_match("/(.*){([^\\\].*)}/", $value, $matches) && 
+//
+                if(preg_match("/(.*){([^\\\].*)}/", $value, $matches) &&
 					!(preg_match("/(.*){\\\.{.*}.*}/", $value, $matches2)))
 				{
 					$author = explode(" ", $matches[1]);
@@ -117,7 +117,7 @@ class PARSECREATORS
 			$firstname = join(" ", $firstnameArray);
 		return array($firstname, $initials);
 	}
-// surname may have title such as 'den', 'von', 'de la' etc. - characterised by first character lowercased.  Any 
+// surname may have title such as 'den', 'von', 'de la' etc. - characterised by first character lowercased.  Any
 // uppercased part means lowercased parts following are part of the surname (e.g. Van den Bussche)
 	function grabSurname($input)
 	{
@@ -144,4 +144,3 @@ class PARSECREATORS
 		return array($surname, FALSE);
 	}
 }
-?>

--- a/library/bibtexParse/PARSECREATORS.php
+++ b/library/bibtexParse/PARSECREATORS.php
@@ -27,13 +27,13 @@ http://bibliophile.sourceforge.net
 
 class PARSECREATORS
 {
-	function ___construct()
+	function __construct()
 	{
 	}
 
 	function PARSECREATORS()
 	{
-		self::___construct();
+		self::__construct();
 	}
 /* Create writer arrays from bibtex input.
 'author field can be (delimiters between authors are 'and' or '&'):

--- a/library/bibtexParse/PARSEENTRIES.php
+++ b/library/bibtexParse/PARSEENTRIES.php
@@ -2,7 +2,7 @@
 /*
 v21
 
-Inspired by an awk BibTeX parser written by Nelson H. F. Beebe over 20 years ago although 
+Inspired by an awk BibTeX parser written by Nelson H. F. Beebe over 20 years ago although
 little of that remains.
 
 Released through http://bibliophile.sourceforge.net under the GPL licence.
@@ -10,7 +10,7 @@ Do whatever you like with this -- some credit to the author(s) would be apprecia
 
 A collection of PHP classes to manipulate bibtex files.
 
-If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net 
+If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net
 so that your improvements can be added to the release package.
 
 Mark Grimshaw 2006
@@ -34,21 +34,21 @@ http://bibliophile.sourceforge.net
                            someField = {value}}
 
 	v2 ****************************************** v2
-						   
-30/01/2006 v2.0 Esteban Zimanyi 
+
+30/01/2006 v2.0 Esteban Zimanyi
     - Add support for @string defined by other strings as in @string( AA = BB # " xx " # C }
     - Add support for comments as defined in Bibtex, i.e., ignores everything that is outside
-      entries delimited by '@' and the closing delimiter. In particular, comments in Bibtex do not 
+      entries delimited by '@' and the closing delimiter. In particular, comments in Bibtex do not
       necessarily have a % at the begining of the line !
 This required a complete rewrite of many functions as well as writing new ones !
 
 31/01/2006 Mark Grimshaw
    - Ensured that @comment{...} is ignored in parseEntry().
-   - Modified extractEntries() to ensure that entries where the start brace/parenthesis is on a 
+   - Modified extractEntries() to ensure that entries where the start brace/parenthesis is on a
      new line are properly parsed.
-	 
+
 10/02/2006 Mark Grimshaw
-  - A 4th array, $this->undefinedStrings, is now returned that holds field values that are judged to be undefined strings.  
+  - A 4th array, $this->undefinedStrings, is now returned that holds field values that are judged to be undefined strings.
 i.e. they are a non-numeric value that is not defined in a @string{...} entry and not enclosed by braces or double-quotes.
 This array will be empty unless the following condition is met:
 ($this->removeDelimit || $this->expandMacro && $this->fieldExtract)
@@ -98,7 +98,7 @@ This array will be empty unless the following condition is met:
                citeulike-article-id = {12222
     }
                ,
-               ignoreMe = {blah}, }    
+               ignoreMe = {blah}, }
 
 @article
 {
@@ -202,7 +202,7 @@ class PARSEENTRIES
 	}
 // Extract value part of @string field enclosed by double-quotes or braces.
 // The string may be expanded with previously-defined strings
-	function extractStringValue($string) 
+	function extractStringValue($string)
 	{
 		// $string contains a end delimiter, remove it
 		$string = trim(substr($string,0,strlen($string)-1));
@@ -249,7 +249,7 @@ class PARSEENTRIES
 			$oldString .= ',';
 		$keys = preg_split("/=,/", $oldString);
 		// 22/08/2004 - Mark Grimshaw
-		// I have absolutely no idea why this array_pop is required but it is.  Seems to always be 
+		// I have absolutely no idea why this array_pop is required but it is.  Seems to always be
 		// an empty key at the end after the split which causes problems if not removed.
 		array_pop($keys);
 		foreach($keys as $key)
@@ -273,8 +273,8 @@ class PARSEENTRIES
 // Start splitting a bibtex entry into component fields.
 // Store the entry type and citation.
 	function fullSplit($entry)
-	{        
-		$matches = preg_split("/@(.*)[{(](.*),/U", $entry, 2, PREG_SPLIT_DELIM_CAPTURE); 
+	{
+		$matches = preg_split("/@(.*)[{(](.*),/U", $entry, 2, PREG_SPLIT_DELIM_CAPTURE);
 		$this->entries[$this->count]['bibtexEntryType'] = strtolower(trim($matches[1]));
 		// sometimes a bibtex entry will have no citation key
 		if(preg_match("/=/", $matches[2])) // this is a field
@@ -289,7 +289,7 @@ class PARSEENTRIES
 	{
 		$count = 0;
 		$lastLine = FALSE;
-		if(preg_match("/@(.*)([{(])/U", preg_quote($entry), $matches)) 
+		if(preg_match("/@(.*)([{(])/U", preg_quote($entry), $matches))
 		{
 			if(!array_key_exists(1, $matches))
 				return $lastLine;
@@ -336,11 +336,11 @@ class PARSEENTRIES
 	}
 
 // This function works like explode('#',$val) but has to take into account whether
-// the character # is part of a string (i.e., is enclosed into "..." or {...} ) 
+// the character # is part of a string (i.e., is enclosed into "..." or {...} )
 // or defines a string concatenation as in @string{ "x # x" # ss # {xx{x}x} }
 	function explodeString($val)
 	{
-		$openquote = $bracelevel = $i = $j = 0; 
+		$openquote = $bracelevel = $i = $j = 0;
 		while ($i < strlen($val))
 		{
 			if ($val[$i] == '"')
@@ -360,17 +360,17 @@ class PARSEENTRIES
 		return $strings;
 	}
 
-// This function receives a string and a closing delimiter '}' or ')' 
+// This function receives a string and a closing delimiter '}' or ')'
 // and looks for the position of the closing delimiter taking into
 // account the following Bibtex rules:
 //  * Inside the braces, there can arbitrarily nested pairs of braces,
-//    but braces must also be balanced inside quotes! 
-//  * Inside quotes, to place the " character it is not sufficient 
-//    to simply escape with \": Quotes must be placed inside braces. 
+//    but braces must also be balanced inside quotes!
+//  * Inside quotes, to place the " character it is not sufficient
+//    to simply escape with \": Quotes must be placed inside braces.
 	function closingDelimiter($val,$delimitEnd)
 	{
 //  echo "####>$delimitEnd $val<BR>";
-		$openquote = $bracelevel = $i = $j = 0; 
+		$openquote = $bracelevel = $i = $j = 0;
 		while ($i < strlen($val))
 		{
 			// a '"' found at brace level 0 defines a value such as "ss{\"o}ss"
@@ -401,12 +401,12 @@ class PARSEENTRIES
 			foreach ($stringlist as $str)
 			{
 				// trim the string since usually # is enclosed by spaces
-				$str = trim($str); 
+				$str = trim($str);
 				// replace the string if macro is already defined
 				// strtolower is used since macros are case insensitive
 				if (isset($this->strings[strtolower($str)]))
 					$string .= $this->strings[strtolower($str)];
-				else 
+				else
 					$string .= $this->removeDelimiters(trim($str));
 			}
 		}
@@ -414,9 +414,9 @@ class PARSEENTRIES
 	}
 
 // This function extract entries taking into account how comments are defined in BibTeX.
-// BibTeX splits the file in two areas: inside an entry and outside an entry, the delimitation 
-// being indicated by the presence of a @ sign. When this character is met, BibTex expects to 
-// find an entry. Before that sign, and after an entry, everything is considered a comment! 
+// BibTeX splits the file in two areas: inside an entry and outside an entry, the delimitation
+// being indicated by the presence of a @ sign. When this character is met, BibTex expects to
+// find an entry. Before that sign, and after an entry, everything is considered a comment!
 	public function extractEntries()
 	{
 		$inside =   $possibleEntryStart = FALSE;
@@ -448,7 +448,7 @@ class PARSEENTRIES
 				$entry .= " ".$line;
 				if ($j=$this->closingDelimiter($entry,$delimitEnd))
 				{
-					// all characters after the delimiter are thrown but the remaining 
+					// all characters after the delimiter are thrown but the remaining
 					// characters must be kept since they may start the next entry !!!
 					$lastLine = substr($entry,$j+1);
 					$entry = substr($entry,0,$j+1);
@@ -458,9 +458,9 @@ class PARSEENTRIES
 					$entry = preg_replace('/{[ \t]+}/', ' ', $entry);
 					$this->parseEntry($entry);
 					$entry = strchr($lastLine,"@");
-					if ($entry) 
+					if ($entry)
 						$inside = TRUE;
-					else 
+					else
 						$inside = FALSE;
 				}
 			}
@@ -481,11 +481,11 @@ class PARSEENTRIES
 		if($this->fieldExtract)
 		{
 			// Next lines must take into account strings defined by previously-defined strings
-			$strings = $this->strings; 
+			$strings = $this->strings;
 			// $this->strings is initialized with strings provided by user if they exists
-			// it is supposed that there are no substitutions to be made in the user strings, i.e., no # 
-			$this->strings = isset($this->userStrings) ? $this->userStrings : array() ; 
-			foreach($strings as $value) 
+			// it is supposed that there are no substitutions to be made in the user strings, i.e., no #
+			$this->strings = isset($this->userStrings) ? $this->userStrings : array() ;
+			foreach($strings as $value)
 			{
 				// changed 21/08/2004 G. Gardey
 				// 23/08/2004 Mark G. account for comments on same line as @string - count delimiters in string value
@@ -494,7 +494,7 @@ class PARSEENTRIES
 				$delimit = $matches[1];
 				$matches = preg_split("/=/", $matches[2], 2, PREG_SPLIT_DELIM_CAPTURE);
 				// macros are case insensitive
-				$this->strings[strtolower(trim($matches[0]))] = $this->extractStringValue($matches[1]); 
+				$this->strings[strtolower(trim($matches[0]))] = $this->extractStringValue($matches[1]);
 			}
 		}
 		// changed 21/08/2004 G. Gardey
@@ -505,13 +505,13 @@ class PARSEENTRIES
 			for($i = 0; $i < count($this->entries); $i++)
 			{
 				foreach($this->entries[$i] as $key => $value)
-				// 02/05/2005 G. Gardey don't expand macro for bibtexCitation 
+				// 02/05/2005 G. Gardey don't expand macro for bibtexCitation
 				// and bibtexEntryType
 				if($key != 'bibtexCitation' && $key != 'bibtexEntryType')
-					$this->entries[$i][$key] = trim($this->removeDelimitersAndExpand($this->entries[$i][$key])); 
+					$this->entries[$i][$key] = trim($this->removeDelimitersAndExpand($this->entries[$i][$key]));
 			}
 		}
-// EZ: Remove this to be able to use the same instance for parsing several files, 
+// EZ: Remove this to be able to use the same instance for parsing several files,
 // e.g., parsing a entry file with its associated abbreviation file
 //		if(empty($this->preamble))
 //			$this->preamble = FALSE;
@@ -522,5 +522,3 @@ class PARSEENTRIES
 		return array($this->preamble, $this->strings, $this->entries, $this->undefinedStrings);
 	}
 }
-?>
-

--- a/library/bibtexParse/PARSEENTRIES.php
+++ b/library/bibtexParse/PARSEENTRIES.php
@@ -132,7 +132,7 @@ END;
 
 class PARSEENTRIES
 {
-	function PARSEENTRIES()
+	function __construct()
 	{
 		$this->preamble = $this->strings = $this->undefinedStrings = $this->entries = array();
 		$this->count = 0;
@@ -142,6 +142,12 @@ class PARSEENTRIES
 		$this->parseFile = TRUE;
 		$this->outsideEntry = TRUE;
 	}
+
+	function PARSEENTRIES()
+	{
+        self::__construct();
+    }
+
 // Open bib file
 	function openBib($file)
 	{

--- a/library/bibtexParse/PARSEMONTH.php
+++ b/library/bibtexParse/PARSEMONTH.php
@@ -5,7 +5,7 @@ Do whatever you like with this -- some credit to the author(s) would be apprecia
 
 A collection of PHP classes to manipulate bibtex files.
 
-If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net so 
+If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net so
 that your improvements can be added to the release package.
 
 Mark Grimshaw 2005
@@ -114,4 +114,3 @@ class PARSEMONTH
 			);
 	}
 }
-?>

--- a/library/bibtexParse/PARSEMONTH.php
+++ b/library/bibtexParse/PARSEMONTH.php
@@ -26,9 +26,16 @@ http://bibliophile.sourceforge.net
 class PARSEMONTH
 {
 // Constructor
+	function __construct()
+	{
+
+	}
+
 	function PARSEMONTH()
 	{
+		self::__construct();
 	}
+	
 	function init($monthField)
 	{
 		$startMonth = $this->startDay = $endMonth = $this->endDay = FALSE;

--- a/library/bibtexParse/PARSEPAGE.php
+++ b/library/bibtexParse/PARSEPAGE.php
@@ -5,7 +5,7 @@ Do whatever you like with this -- some credit to the author(s) would be apprecia
 
 A collection of PHP classes to manipulate bibtex files.
 
-If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net 
+If you make improvements, please consider contacting the administrators at bibliophile.sourceforge.net
 so that your improvements can be added to the release package.
 
 Mark Grimshaw 2005
@@ -63,4 +63,3 @@ class PARSEPAGE
 		return FALSE;
 	}
 }
-?>

--- a/library/bibtexParse/PARSEPAGE.php
+++ b/library/bibtexParse/PARSEPAGE.php
@@ -16,8 +16,13 @@ http://bibliophile.sourceforge.net*/
 class PARSEPAGE
 {
 // Constructor
+	function __construct()
+	{
+	}
+
 	function PARSEPAGE()
 	{
+		self:__construct();
 	}
 // Create page arrays from bibtex input.
 // 'pages' field can be:


### PR DESCRIPTION
The trailing blank line(s) were leading to empty lines at the top of the page due to the includes of these in autoload.php

        "files": [
            "library/bibtexParse/PARSEENTRIES.php",
            "library/bibtexParse/PARSECREATORS.php",
            "library/bibtexParse/PARSEMONTH.php",
            "library/bibtexParse/PARSEPAGE.php"
        ]

Removing the trailing ?> avoids this issue 
(see http://php.net/manual/en/language.basic-syntax.phptags.php: If a file is pure PHP code, it is preferable to omit the PHP closing tag at the end of the file. )

While making this change, I converted to UNIX line-endings in order to be consistent with the line endings in src/