### PR TITLE
Switch back to valid semver version for technosophos/LibRIS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require":{
         "php":">=5.3.0",
-        "technosophos/LibRIS": "^2.0.2"
+        "technosophos/libris": "^2.0.2"
     },
     "autoload":{
         "psr-0":{

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require":{
         "php":">=5.3.0",
-        "technosophos/LibRIS": "dev-master"
+        "technosophos/LibRIS": "^2.0.2"
     },
     "autoload":{
         "psr-0":{


### PR DESCRIPTION
The latest changes in dev-master from this package are also in 2.0.2.

https://packagist.org/packages/technosophos/libris

Also changed the package name to be lower case as uppercase names are deprecated in composer.

Fixes #9